### PR TITLE
Install `bash-completion`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM ghcr.io/qmk/qmk_cli:latest
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
+    bash-completion \
     cron \
     curl \
     jq \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Seems to be missing in the base install? It got annoying having to type out git commands in full.
